### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -17,6 +17,9 @@ on:
       - 'tests/**'
       - '.github/**'
 
+permissions:
+  contents: read
+
 jobs:
   performance_test:
     runs-on: ubuntu-latest
@@ -25,17 +28,17 @@ jobs:
         modsec_version: [modsec2-apache]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
       - name: "Setup Python"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.11'
 
       - name: "Install Poetry"
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: 1.5.1
           virtualenvs-create: true
@@ -79,7 +82,7 @@ jobs:
           poetry run report --test-name pipeline-test --utils ftw --threshold-conf './config' >> $GITHUB_STEP_SUMMARY
           poetry run report --test-name pipeline-test --utils locust >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: data
           path: data

--- a/.github/workflows/pipeline_demo.yml
+++ b/.github/workflows/pipeline_demo.yml
@@ -5,14 +5,19 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   push_to_pipeline_demo:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CoreRuleSetBranch: "v4.0/dev"
     steps:
       - name: git-checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: initialize
         run: |
@@ -31,7 +36,7 @@ jobs:
           printf '%s\n' "${ignore_list[@]}" >> .gitignore
 
       - name: push
-        uses: s0/git-publish-subdir-action@develop
+        uses: s0/git-publish-subdir-action@ac113f6bfe8896e85a373534242c949a7ea74c98 # develop
         env:
           REPO: self
           BRANCH: demo


### PR DESCRIPTION
## what

- pin all third-party actions to commit SHAs (`actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `snok/install-poetry`, `s0/git-publish-subdir-action`)
- add explicit minimal `permissions` blocks to all workflows

## why

- unpinned actions reference mutable tags that can be moved by upstream maintainers or attackers
- pipeline_demo.yml uses `s0/git-publish-subdir-action@develop` (mutable branch) with `GITHUB_TOKEN` write access — a compromised upstream could push arbitrary code to the repo
- explicit permissions follow the principle of least privilege

## refs

- [GitHub docs: security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)